### PR TITLE
Remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-https://waffle.js.org


### PR DESCRIPTION
Removes CNAME so that we can preview the GH pages site as we build it.